### PR TITLE
redaction logs + metrics enhancement

### DIFF
--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/span/normalizer/constants/SpanNormalizerConstants.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/span/normalizer/constants/SpanNormalizerConstants.java
@@ -7,7 +7,10 @@ public class SpanNormalizerConstants {
   public static final String SPAN_NORMALIZER_JOB_CONFIG = "span-normalizer-job-config";
   public static final String BYPASS_OUTPUT_TOPIC_CONFIG_KEY = "bypass.output.topic";
   public static final String PII_KEYS_CONFIG_KEY = "pii.keys";
+  public static final String PII_CONFIG_KEY = "pii";
   public static final String PII_REGEX_CONFIG_KEY = "pii.regex";
   public static final String PII_FIELD_REDACTED_VAL = "[redacted]";
   public static final String CONTAINS_PII_TAGS_KEY = "containsPIITags";
+  public static final String MAX_REDACTED_SPAN_METRIC_COUNTERS_CONFIG_KEY =
+      "pii.max.redacted.span.metric.counters";
 }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -255,19 +255,19 @@ public class JaegerSpanNormalizer {
 
   private void logSpanRedaction(String tagKey, String spanServiceName, PIIMatchType matchType) {
     try {
-        LOG.info(
-            new ObjectMapper()
-                .writerWithDefaultPrettyPrinter()
-                .writeValueAsString(
-                    Map.of(
-                        "bookmark",
-                        "REDACTED_KEY",
-                        "key",
-                        tagKey,
-                        "matchtype",
-                        matchType.toString(),
-                        "serviceName",
-                        spanServiceName)));
+      LOG.info(
+          new ObjectMapper()
+              .writerWithDefaultPrettyPrinter()
+              .writeValueAsString(
+                  Map.of(
+                      "bookmark",
+                      "REDACTED_KEY",
+                      "key",
+                      tagKey,
+                      "matchtype",
+                      matchType.toString(),
+                      "serviceName",
+                      spanServiceName)));
     } catch (Exception e) {
       LOG.error("An exception occurred while logging span redaction: ", e);
     }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -13,7 +13,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,6 +45,7 @@ import org.hypertrace.core.datamodel.Metrics;
 import org.hypertrace.core.datamodel.RawSpan;
 import org.hypertrace.core.datamodel.RawSpan.Builder;
 import org.hypertrace.core.datamodel.eventfields.jaeger.JaegerFields;
+import org.hypertrace.core.datamodel.shared.HexUtils;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.hypertrace.core.span.constants.RawSpanConstants;
@@ -193,7 +193,7 @@ public class JaegerSpanNormalizer {
       var attributeMap = rawSpanBuilder.getEvent().getAttributes().getAttributeMap();
       var spanEventName = rawSpanBuilder.getEvent().getEventName();
       var spanEventId =
-          StandardCharsets.UTF_8.decode(rawSpanBuilder.getEvent().getEventId()).toString();
+              Optional.ofNullable(rawSpanBuilder.getEvent().getEventId()).map(HexUtils::getHex).orElse(null);
       Set<String> tagKeys = attributeMap.keySet();
 
       AtomicReference<Boolean> containsPIIFields = new AtomicReference<>();

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -192,7 +192,8 @@ public class JaegerSpanNormalizer {
     try {
       var attributeMap = rawSpanBuilder.getEvent().getAttributes().getAttributeMap();
       var spanEventName = rawSpanBuilder.getEvent().getEventName();
-      var spanEventId = StandardCharsets.UTF_8.decode(rawSpanBuilder.getEvent().getEventId()).toString();
+      var spanEventId =
+          StandardCharsets.UTF_8.decode(rawSpanBuilder.getEvent().getEventId()).toString();
       Set<String> tagKeys = attributeMap.keySet();
 
       AtomicReference<Boolean> containsPIIFields = new AtomicReference<>();
@@ -255,7 +256,7 @@ public class JaegerSpanNormalizer {
           tagKey,
           matchType.toString(),
           spanEventName,
-              spanEventId);
+          spanEventId);
       String metricKey = tagKey + "#" + spanEventName;
       if (spanAttributesRedactedCounters.size() < MAX_REDACTED_SPAN_METRIC_COUNTERS) {
         spanAttributesRedactedCounters

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -255,8 +255,7 @@ public class JaegerSpanNormalizer {
 
   private void logSpanRedaction(String tagKey, String spanServiceName, PIIMatchType matchType) {
     try {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(
+        LOG.info(
             new ObjectMapper()
                 .writerWithDefaultPrettyPrinter()
                 .writeValueAsString(
@@ -269,7 +268,6 @@ public class JaegerSpanNormalizer {
                         matchType.toString(),
                         "serviceName",
                         spanServiceName)));
-      }
     } catch (Exception e) {
       LOG.error("An exception occurred while logging span redaction: ", e);
     }

--- a/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -193,7 +193,9 @@ public class JaegerSpanNormalizer {
       var attributeMap = rawSpanBuilder.getEvent().getAttributes().getAttributeMap();
       var spanEventName = rawSpanBuilder.getEvent().getEventName();
       var spanEventId =
-              Optional.ofNullable(rawSpanBuilder.getEvent().getEventId()).map(HexUtils::getHex).orElse(null);
+          Optional.ofNullable(rawSpanBuilder.getEvent().getEventId())
+              .map(HexUtils::getHex)
+              .orElse(null);
       Set<String> tagKeys = attributeMap.keySet();
 
       AtomicReference<Boolean> containsPIIFields = new AtomicReference<>();

--- a/span-normalizer/span-normalizer/src/main/resources/configs/common/application.conf
+++ b/span-normalizer/span-normalizer/src/main/resources/configs/common/application.conf
@@ -37,4 +37,5 @@ metrics.reportInterval = 60
 pii = {
   keys = ["authorization"]
   regex = []
+  max.redacted.span.metric.counters = 100
 }

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -2,6 +2,7 @@ package org.hypertrace.core.spannormalizer.jaeger;
 
 import static org.hypertrace.core.span.constants.v1.Http.HTTP_REQUEST_METHOD;
 
+import com.google.protobuf.ByteString;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import io.jaegertracing.api_v2.JaegerSpanInternalModel.KeyValue;
@@ -258,6 +259,7 @@ public class JaegerSpanNormalizerTest {
             .addTags(8, KeyValue.newBuilder().setKey("phoneNum3").setVStr("123456789").build())
             .addTags(9, KeyValue.newBuilder().setKey("otp").setVStr("[redacted]").build())
             .setOperationName("redaction operation")
+                .setSpanId(ByteString.copyFromUtf8("1"))
             .build();
 
     RawSpan rawSpan = normalizer.convert(tenantId, span);
@@ -306,6 +308,7 @@ public class JaegerSpanNormalizerTest {
         Span.newBuilder()
             .setProcess(process)
             .addTags(0, KeyValue.newBuilder().setKey("otp").setVStr("[redacted]").build())
+                .setSpanId(ByteString.copyFromUtf8("2"))
             .build();
     rawSpan = normalizer.convert(tenantId, span);
     attributes = rawSpan.getEvent().getAttributes().getAttributeMap();
@@ -325,6 +328,7 @@ public class JaegerSpanNormalizerTest {
               .addTags(
                   0,
                   KeyValue.newBuilder().setKey("amount").setVStr("spanCount:" + spanCount).build())
+                  .setSpanId(ByteString.copyFromUtf8("3"))
               .build();
       normalizer.convert(tenantId, span);
     }

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -259,7 +259,7 @@ public class JaegerSpanNormalizerTest {
             .addTags(8, KeyValue.newBuilder().setKey("phoneNum3").setVStr("123456789").build())
             .addTags(9, KeyValue.newBuilder().setKey("otp").setVStr("[redacted]").build())
             .setOperationName("redaction operation")
-            .setSpanId(ByteString.copyFromUtf8("1"))
+            .setSpanId(ByteString.copyFrom("1".getBytes()))
             .build();
 
     RawSpan rawSpan = normalizer.convert(tenantId, span);

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -259,7 +259,7 @@ public class JaegerSpanNormalizerTest {
             .addTags(8, KeyValue.newBuilder().setKey("phoneNum3").setVStr("123456789").build())
             .addTags(9, KeyValue.newBuilder().setKey("otp").setVStr("[redacted]").build())
             .setOperationName("redaction operation")
-                .setSpanId(ByteString.copyFromUtf8("1"))
+            .setSpanId(ByteString.copyFromUtf8("1"))
             .build();
 
     RawSpan rawSpan = normalizer.convert(tenantId, span);
@@ -308,7 +308,7 @@ public class JaegerSpanNormalizerTest {
         Span.newBuilder()
             .setProcess(process)
             .addTags(0, KeyValue.newBuilder().setKey("otp").setVStr("[redacted]").build())
-                .setSpanId(ByteString.copyFromUtf8("2"))
+            .setSpanId(ByteString.copyFromUtf8("2"))
             .build();
     rawSpan = normalizer.convert(tenantId, span);
     attributes = rawSpan.getEvent().getAttributes().getAttributeMap();
@@ -328,7 +328,7 @@ public class JaegerSpanNormalizerTest {
               .addTags(
                   0,
                   KeyValue.newBuilder().setKey("amount").setVStr("spanCount:" + spanCount).build())
-                  .setSpanId(ByteString.copyFromUtf8("3"))
+              .setSpanId(ByteString.copyFromUtf8("3"))
               .build();
       normalizer.convert(tenantId, span);
     }

--- a/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizerTest.java
@@ -23,7 +23,6 @@ import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.JaegerAttribute;
 import org.hypertrace.core.spannormalizer.SpanNormalizer;
 import org.hypertrace.core.spannormalizer.constants.SpanNormalizerConstants;
-import org.hypertrace.core.spannormalizer.jaeger.tenant.PIIMatchType;
 import org.hypertrace.core.spannormalizer.utils.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -258,6 +257,7 @@ public class JaegerSpanNormalizerTest {
             .addTags(7, KeyValue.newBuilder().setKey("phoneNum2").setVStr("+1234567890").build())
             .addTags(8, KeyValue.newBuilder().setKey("phoneNum3").setVStr("123456789").build())
             .addTags(9, KeyValue.newBuilder().setKey("otp").setVStr("[redacted]").build())
+            .setOperationName("redaction operation")
             .build();
 
     RawSpan rawSpan = normalizer.convert(tenantId, span);
@@ -283,8 +283,21 @@ public class JaegerSpanNormalizerTest {
     Assertions.assertEquals("123456789", attributes.get("phonenum3").getValue());
     Assertions.assertEquals(
         SpanNormalizerConstants.PII_FIELD_REDACTED_VAL, attributes.get("otp").getValue());
-    Assertions.assertEquals(5.0, counterMap.get(PIIMatchType.KEY.toString()).count());
-    Assertions.assertEquals(2.0, counterMap.get(PIIMatchType.REGEX.toString()).count());
+    Assertions.assertEquals(7, counterMap.size());
+    Assertions.assertEquals(1.0, counterMap.get("http.url#redaction operation").count());
+    Assertions.assertEquals(
+        "redaction operation",
+        counterMap.get("http.url#redaction operation").getId().getTag("spanEventName"));
+    Assertions.assertEquals(
+        "http.url", counterMap.get("http.url#redaction operation").getId().getTag("tagKey"));
+    Assertions.assertEquals(
+        "redaction operation",
+        counterMap.get("http.url#redaction operation").getId().getTag("spanEventName"));
+    Assertions.assertEquals(
+        "phonenum1", counterMap.get("phonenum1#redaction operation").getId().getTag("tagKey"));
+    Assertions.assertEquals(
+        "redaction operation",
+        counterMap.get("phonenum1#redaction operation").getId().getTag("spanEventName"));
     Assertions.assertTrue(attributes.containsKey(SpanNormalizerConstants.CONTAINS_PII_TAGS_KEY));
     Assertions.assertEquals(
         "true", attributes.get(SpanNormalizerConstants.CONTAINS_PII_TAGS_KEY).getValue());
@@ -294,17 +307,70 @@ public class JaegerSpanNormalizerTest {
             .setProcess(process)
             .addTags(0, KeyValue.newBuilder().setKey("otp").setVStr("[redacted]").build())
             .build();
-
     rawSpan = normalizer.convert(tenantId, span);
     attributes = rawSpan.getEvent().getAttributes().getAttributeMap();
     counterMap = normalizer.getSpanAttributesRedactedCounters();
 
-    Assertions.assertEquals(6.0, counterMap.get(PIIMatchType.KEY.toString()).count());
-    Assertions.assertEquals(2.0, counterMap.get(PIIMatchType.REGEX.toString()).count());
+    Assertions.assertEquals(8, counterMap.size());
     Assertions.assertEquals(
         SpanNormalizerConstants.PII_FIELD_REDACTED_VAL, attributes.get("otp").getValue());
     Assertions.assertEquals(
         "true", attributes.get(SpanNormalizerConstants.CONTAINS_PII_TAGS_KEY).getValue());
+
+    for (int spanCount = 1; spanCount <= 150; spanCount++) {
+      span =
+          Span.newBuilder()
+              .setProcess(process)
+              .setOperationName("random event" + spanCount)
+              .addTags(
+                  0,
+                  KeyValue.newBuilder().setKey("amount").setVStr("spanCount:" + spanCount).build())
+              .build();
+      normalizer.convert(tenantId, span);
+    }
+
+    Assertions.assertEquals(100, counterMap.size());
+
+    Map<String, Object> newConfig = new HashMap<>(getCommonConfig());
+    newConfig.put("max.redacted.span.metric.counters", 101);
+    normalizer = JaegerSpanNormalizer.get(ConfigFactory.parseMap(newConfig));
+    for (int spanCount = 1; spanCount <= 10; spanCount++) {
+      span =
+          Span.newBuilder()
+              .setProcess(process)
+              .setOperationName("random event" + spanCount)
+              .addTags(
+                  0,
+                  KeyValue.newBuilder().setKey("amount").setVStr("spanCount:" + spanCount).build())
+              .build();
+      normalizer.convert(tenantId, span);
+    }
+
+    Assertions.assertEquals(100, counterMap.size());
+  }
+
+  @Test
+  public void testPiiFieldRedactionMetrics() throws Exception {
+    Map<String, Object> newConfig = new HashMap<>(getCommonConfig());
+    newConfig.put(SpanNormalizerConstants.MAX_REDACTED_SPAN_METRIC_COUNTERS_CONFIG_KEY, 101);
+    String tenantId = "tenant-" + random.nextLong();
+    newConfig.putAll(Map.of("processor", Map.of("defaultTenantId", tenantId)));
+    JaegerSpanNormalizer normalizer = JaegerSpanNormalizer.get(ConfigFactory.parseMap(newConfig));
+    Process process = Process.newBuilder().build();
+
+    for (int spanCount = 1; spanCount <= 150; spanCount++) {
+      Span span =
+          Span.newBuilder()
+              .setProcess(process)
+              .setOperationName("random event" + spanCount)
+              .addTags(
+                  0,
+                  KeyValue.newBuilder().setKey("amount").setVStr("spanCount:" + spanCount).build())
+              .build();
+      normalizer.convert(tenantId, span);
+    }
+
+    Assertions.assertEquals(101, normalizer.getSpanAttributesRedactedCounters().size());
   }
 
   @Test


### PR DESCRIPTION
[_index=stage_hypertrace_infrequent 
AND "REDACTED_KEY"](https://service.in.sumologic.com/ui/#/search/create?id=hNbhKmSMmREbQ2oCEIQTLXzD2XxyREzeZZMKyEuQ)

The below code only prints the one key-value pair at a time in sumo, and sumo breaks the logs printing each key-val pair individually. pls, Check the above link for more info.

```
new ObjectMapper()
                .writerWithDefaultPrettyPrinter()
                .writeValueAsString(
                    Map.of(
                        "bookmark",
                        "REDACTED_KEY",
                        "key",
                        tagKey,
                        "matchtype",
                        matchType.toString(),
                        "serviceName",
                        spanServiceName)));
```
Plus adding useful metrics - [https://grafana.np.razorpay.in/d/cZKGhuHMk1/ht-ingester-admin-port-metrics?editPanel=153&orgId=1&refresh=1m&from=now-24h&to=now](https://grafana.np.razorpay.in/d/cZKGhuHMk1/ht-ingester-admin-port-metrics?editPanel=153&orgId=1&refresh=1m&from=now-24h&to=now)