### PR TITLE
Github action for release having docker Image with Tag as version number

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -36,10 +36,15 @@ jobs:
             gradle-packages-${{ runner.os }}-${{ github.job }}
             gradle-packages-${{ runner.os }}
 
+      - name: Show Github ENV variables
+        run: env | grep ^GITHUB
+
       - name: Build with Gradle
         uses: hypertrace/github-actions/gradle@main
         with: 
           args: dockerBuildImages
+        env:
+          IMAGE_TAG: ${GITHUB_SHA}
 
       - name: Verify hypertrace image
         working-directory: ./.github/workflows/hypertrace-ingester
@@ -86,6 +91,8 @@ jobs:
         uses: hypertrace/github-actions/gradle@main
         with: 
           args: dockerBuildImages
+        env:
+          IMAGE_TAG: ${GITHUB_SHA}
 
       - name: Verify hypertrace image
         working-directory: ./.github/workflows/hypertrace-ingester

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -36,15 +36,12 @@ jobs:
             gradle-packages-${{ runner.os }}-${{ github.job }}
             gradle-packages-${{ runner.os }}
 
-      - name: Show Github ENV variables
-        run: env | grep ^GITHUB
-
       - name: Build with Gradle
         uses: hypertrace/github-actions/gradle@main
         with: 
           args: dockerBuildImages
         env:
-          IMAGE_TAG: ${GITHUB_SHA}
+          IMAGE_TAG: ${{ github.sha }}
 
       - name: Verify hypertrace image
         working-directory: ./.github/workflows/hypertrace-ingester
@@ -92,7 +89,7 @@ jobs:
         with: 
           args: dockerBuildImages
         env:
-          IMAGE_TAG: ${GITHUB_SHA}
+          IMAGE_TAG: ${{ github.sha }}
 
       - name: Verify hypertrace image
         working-directory: ./.github/workflows/hypertrace-ingester

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           args: build dockerBuildImages
         env:
-          IMAGE_TAG: ${GITHUB_SHA}
+          IMAGE_TAG: ${{ github.sha }}
 
       - name: push docker image
         uses: hypertrace/github-actions/gradle@main
@@ -93,6 +93,7 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.PUBLIC_DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.PUBLIC_DOCKER_PASSWORD }}
+          IMAGE_TAG: ${{ github.sha }}
 
 #   snyk-scan:
 #     runs-on: ubuntu-20.04

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -83,6 +83,8 @@ jobs:
         uses: hypertrace/github-actions/gradle@main
         with:
           args: build dockerBuildImages
+        env:
+          IMAGE_TAG: ${GITHUB_SHA}
 
       - name: push docker image
         uses: hypertrace/github-actions/gradle@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release artifacts
+on:
+#  Will run when a comment is added in PR e.g. /release v0.6.40-0.1.0-beta.1
+  issue_comment:
+    types: [ created ]
+  workflow_dispatch:
+
+jobs:
+  publish-artifacts:
+    if: contains(github.event.comment.html_url, '/pull') && startsWith(github.event.comment.body, '/release v')
+    runs-on: ubuntu-20.04
+    steps:
+      # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.PUBLIC_DOCKER_USERNAME }}
+          password: ${{ secrets.PUBLIC_DOCKER_PASSWORD }}
+
+      - name: Set ENV variable
+        env:
+          RELEASE_VERSION_COMMENT: ${{ github.event.comment.body }}
+        run: |
+          echo "VERSION=${RELEASE_VERSION_COMMENT##/release\ v}" >> $GITHUB_ENV
+          echo "Setting tag version: ${VERSION}"
+
+      - name: Build with Gradle
+        uses: hypertrace/github-actions/gradle@main
+        with:
+          args: build dockerBuildImages
+        env:
+          DOCKER_USERNAME: ${{ secrets.PUBLIC_DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.PUBLIC_DOCKER_PASSWORD }}
+          IMAGE_TAG: ${{ env.VERSION }}
+
+      - name: push docker image
+        uses: hypertrace/github-actions/gradle@main
+        with:
+          args: dockerPushImages
+        env:
+          DOCKER_USERNAME: ${{ secrets.PUBLIC_DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.PUBLIC_DOCKER_PASSWORD }}

--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -168,11 +168,4 @@ tasks.register<Copy>("createCopySpecForSubJobTest") {
   ).into("./build/resources/test/configs/")
 }
 
-fun getCommitHash(): String {
-  val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-  project.exec {
-    commandLine = "git rev-parse --verify HEAD".split(" ")
-    standardOutput = os
-  }
-  return String(os.toByteArray()).trim()
-}
+

--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -24,7 +24,7 @@ hypertraceDocker {
     }
     namespace.set("razorpay")
   }
-  tag("${project.name}" + "_" + getCommitHash())
+  tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 dependencies {

--- a/hypertrace-ingester/build.gradle.kts
+++ b/hypertrace-ingester/build.gradle.kts
@@ -167,5 +167,3 @@ tasks.register<Copy>("createCopySpecForSubJobTest") {
           createCopySpecForSubJob("hypertrace-view-generator", "hypertrace-view-generator", "test")
   ).into("./build/resources/test/configs/")
 }
-
-

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -23,14 +23,7 @@ hypertraceDocker {
   tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
-fun getCommitHash(): String {
-  val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-  project.exec {
-    commandLine = "git rev-parse --verify HEAD".split(" ")
-    standardOutput = os
-  }
-  return String(os.toByteArray()).trim()
-}
+
 
 tasks.test {
   useJUnitPlatform()

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -23,8 +23,6 @@ hypertraceDocker {
   tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
-
-
 tasks.test {
   useJUnitPlatform()
 }

--- a/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
+++ b/hypertrace-metrics-exporter/hypertrace-metrics-exporter/build.gradle.kts
@@ -20,7 +20,7 @@ hypertraceDocker {
     }
     namespace.set("razorpay")
   }
-  tag("${project.name}" + "_" + getCommitHash())
+  tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 fun getCommitHash(): String {

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
@@ -23,14 +23,7 @@ hypertraceDocker {
   tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
-fun getCommitHash(): String {
-  val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-  project.exec {
-    commandLine = "git rev-parse --verify HEAD".split(" ")
-    standardOutput = os
-  }
-  return String(os.toByteArray()).trim()
-}
+
 
 tasks.test {
   useJUnitPlatform()

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
@@ -23,8 +23,6 @@ hypertraceDocker {
   tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
-
-
 tasks.test {
   useJUnitPlatform()
 }

--- a/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
+++ b/hypertrace-metrics-generator/hypertrace-metrics-generator/build.gradle.kts
@@ -20,7 +20,7 @@ hypertraceDocker {
     }
     namespace.set("razorpay")
   }
-  tag("${project.name}" + "_" + getCommitHash())
+  tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 fun getCommitHash(): String {

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -23,14 +23,7 @@ hypertraceDocker {
   tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
-fun getCommitHash(): String {
-  val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-  project.exec {
-    commandLine = "git rev-parse --verify HEAD".split(" ")
-    standardOutput = os
-  }
-  return String(os.toByteArray()).trim()
-}
+
 
 tasks.test {
   useJUnitPlatform()

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -23,8 +23,6 @@ hypertraceDocker {
   tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
-
-
 tasks.test {
   useJUnitPlatform()
 }

--- a/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
+++ b/hypertrace-metrics-processor/hypertrace-metrics-processor/build.gradle.kts
@@ -20,7 +20,7 @@ hypertraceDocker {
     }
     namespace.set("razorpay")
   }
-  tag("${project.name}" + "_" + getCommitHash())
+  tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 fun getCommitHash(): String {

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -67,11 +67,4 @@ dependencies {
   testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }
 
-fun getCommitHash(): String {
-  val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-  project.exec {
-    commandLine = "git rev-parse --verify HEAD".split(" ")
-    standardOutput = os
-  }
-  return String(os.toByteArray()).trim()
-}
+

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -19,7 +19,7 @@ hypertraceDocker {
     }
     namespace.set("razorpay")
   }
-  tag("${project.name}" + "_" + getCommitHash())
+  tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher/build.gradle.kts
@@ -66,5 +66,3 @@ dependencies {
   testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
   testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }
-
-

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -50,11 +50,4 @@ dependencies {
   testImplementation("com.google.code.gson:gson:2.8.9")
 }
 
-fun getCommitHash(): String {
-  val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-  project.exec {
-    commandLine = "git rev-parse --verify HEAD".split(" ")
-    standardOutput = os
-  }
-  return String(os.toByteArray()).trim()
-}
+

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -49,5 +49,3 @@ dependencies {
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("com.google.code.gson:gson:2.8.9")
 }
-
-

--- a/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
+++ b/hypertrace-view-generator/hypertrace-view-generator/build.gradle.kts
@@ -20,7 +20,7 @@ hypertraceDocker {
     }
     namespace.set("razorpay")
   }
-  tag("${project.name}" + "_" + getCommitHash())
+  tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 tasks.test {

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -63,12 +63,3 @@ dependencies {
     testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
     testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }
-
-fun getCommitHash(): String {
-    val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-    project.exec {
-        commandLine = "git rev-parse --verify HEAD".split(" ")
-        standardOutput = os
-    }
-    return String(os.toByteArray()).trim()
-}

--- a/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
+++ b/raw-spans-grouper/raw-spans-grouper/build.gradle.kts
@@ -19,7 +19,7 @@ hypertraceDocker {
         }
         namespace.set("razorpay")
     }
-    tag("${project.name}" + "_" + getCommitHash())
+    tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -20,7 +20,7 @@ hypertraceDocker {
     }
     namespace.set("razorpay")
   }
-  tag("${project.name}" + "_" + getCommitHash())
+  tag("${project.name}" + "_" + System.getenv("IMAGE_TAG"))
 }
 
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -74,5 +74,3 @@ dependencies {
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }
-
-

--- a/span-normalizer/span-normalizer/build.gradle.kts
+++ b/span-normalizer/span-normalizer/build.gradle.kts
@@ -75,11 +75,4 @@ dependencies {
   testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
 }
 
-fun getCommitHash(): String {
-  val os = com.bmuschko.gradle.docker.shaded.org.apache.commons.io.output.ByteArrayOutputStream()
-  project.exec {
-    commandLine = "git rev-parse --verify HEAD".split(" ")
-    standardOutput = os
-  }
-  return String(os.toByteArray()).trim()
-}
+


### PR DESCRIPTION
When we create a PR and write a comment as "/release {version_number}"

This triggers a github action that will build docker images with above version as tag. 

Once the PR is merged, we can create a release with above tag(version)