### PR TITLE
Add internal_duration_millis to SpanEventView

### DIFF
--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
@@ -17,7 +17,7 @@ public class EnrichedSpanConstants {
   public static final String UNIQUE_API_NODES_COUNT = "unique.apis.count";
   public static final String GRPC_REQUEST_URL = "grpc.request.url";
   public static final String GRPC_REQUEST_ENDPOINT = "grpc.request.endpoint";
-  public static final String INTERNAL_SVC_LATENCY = "enriched.internalDurationMillis";
+  public static final String INTERNAL_SVC_LATENCY = "enriched.internaldurationmillis";
 
   /**
    * Returns the constant value for the given Enum.

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
@@ -17,7 +17,7 @@ public class EnrichedSpanConstants {
   public static final String UNIQUE_API_NODES_COUNT = "unique.apis.count";
   public static final String GRPC_REQUEST_URL = "grpc.request.url";
   public static final String GRPC_REQUEST_ENDPOINT = "grpc.request.endpoint";
-  public static final String INTERNAL_SVC_LATENCY = "enriched.internaldurationmillis";
+  public static final String INTERNAL_SVC_LATENCY = "enriched.internal.duration.millis";
 
   /**
    * Returns the constant value for the given Enum.

--- a/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
+++ b/hypertrace-trace-enricher/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/EnrichedSpanConstants.java
@@ -17,7 +17,7 @@ public class EnrichedSpanConstants {
   public static final String UNIQUE_API_NODES_COUNT = "unique.apis.count";
   public static final String GRPC_REQUEST_URL = "grpc.request.url";
   public static final String GRPC_REQUEST_ENDPOINT = "grpc.request.endpoint";
-  public static final String INTERNAL_SVC_LATENCY = "enriched.serviceInternalProcessingTime";
+  public static final String INTERNAL_SVC_LATENCY = "enriched.internalDurationMillis";
 
   /**
    * Returns the constant value for the given Enum.

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ServiceInternalProcessingTimeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ServiceInternalProcessingTimeEnricher.java
@@ -1,5 +1,7 @@
 package org.hypertrace.traceenricher.enrichment.enrichers;
 
+import static org.hypertrace.core.datamodel.shared.AvroBuilderCache.fastNewBuilder;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -7,6 +9,7 @@ import org.hypertrace.core.datamodel.ApiNodeEventEdge;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.MetricValue;
+import org.hypertrace.core.datamodel.MetricValue.Builder;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.ApiNode;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
@@ -82,7 +85,7 @@ public class ServiceInternalProcessingTimeEnricher extends AbstractTraceEnricher
                 .getMetricMap()
                 .put(
                     EnrichedSpanConstants.INTERNAL_SVC_LATENCY,
-                    MetricValue.newBuilder()
+                    fastNewBuilder(MetricValue.Builder.class)
                         .setValue(
                             entryApiBoundaryEventDuration - totalEdgeDurations - httpExitCallsSum)
                         .build());

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ServiceInternalProcessingTimeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ServiceInternalProcessingTimeEnricher.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.hypertrace.core.datamodel.ApiNodeEventEdge;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.ApiNode;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
@@ -75,6 +76,16 @@ public class ServiceInternalProcessingTimeEnricher extends AbstractTraceEnricher
                             entryApiBoundaryEventDuration
                                 - totalEdgeDurations
                                 - httpExitCallsSum)));
+            // also put into metric map
+            entryApiBoundaryEvent
+                .getMetrics()
+                .getMetricMap()
+                .put(
+                    EnrichedSpanConstants.INTERNAL_SVC_LATENCY,
+                    MetricValue.newBuilder()
+                        .setValue(
+                            entryApiBoundaryEventDuration - totalEdgeDurations - httpExitCallsSum)
+                        .build());
           } catch (NullPointerException e) {
             LOG.error(
                 "NPE while calculating service internal time. entryApiBoundaryEventDuration {}, totalEdgeDurations {}",

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ServiceInternalProcessingTimeEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ServiceInternalProcessingTimeEnricher.java
@@ -9,7 +9,6 @@ import org.hypertrace.core.datamodel.ApiNodeEventEdge;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.MetricValue;
-import org.hypertrace.core.datamodel.MetricValue.Builder;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.ApiNode;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
@@ -56,7 +56,7 @@
               "value_list": null,
               "value_map": null
             },
-            "enriched.internalDurationMillis":{
+            "enriched.internal.duration.millis":{
               "value": {
                 "string": "4041.0"
               },
@@ -80,7 +80,7 @@
               "value_list": null,
               "value_map": null
             },
-            "enriched.internalDurationMillis":{
+            "enriched.internal.duration.millis":{
               "value": {
                 "double": 4041
               },

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
@@ -79,6 +79,14 @@
               "binary_value": null,
               "value_list": null,
               "value_map": null
+            },
+            "enriched.internalDurationMillis":{
+              "value": {
+                "double": 4041
+              },
+              "binary_value":null,
+              "value_list":null,
+              "value_map":null
             }
           }
         }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/test/resources/missing-downstream-entry-spans/after-enrichment.json
@@ -56,7 +56,7 @@
               "value_list": null,
               "value_map": null
             },
-            "enriched.serviceInternalProcessingTime":{
+            "enriched.internalDurationMillis":{
               "value": {
                 "string": "4041.0"
               },

--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
@@ -47,7 +47,8 @@ protocol SpanEventViewProtocol {
     // duration
     long duration_millis = 0;
 
-    long internal_duration_millis = 0;
+    //this will be >=0 only for spans with API_BOUNDARY_TYPE = ENTRY
+    long internal_duration_millis = -1;
 
     // span id of an entry api span.
     union { null, bytes } api_trace_id = null;

--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
@@ -47,6 +47,8 @@ protocol SpanEventViewProtocol {
     // duration
     long duration_millis = 0;
 
+    long internal_duration_millis = 0;
+
     // span id of an entry api span.
     union { null, bytes } api_trace_id = null;
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
@@ -52,6 +52,7 @@ public abstract class BaseViewGenerator<OUT extends GenericRecord>
       return null;
     }
 
+
     AttributeValue attr =
         attributes
             .getAttributeMap()

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
@@ -52,7 +52,6 @@ public abstract class BaseViewGenerator<OUT extends GenericRecord>
       return null;
     }
 
-
     AttributeValue attr =
         attributes
             .getAttributeMap()

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -221,11 +221,11 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
     builder.setDurationMillis(event.getEndTimeMillis() - event.getStartTimeMillis());
 
     // internal duration
-    MetricValue metricValue =
-        event.getMetrics().getMetricMap().get(EnrichedSpanConstants.INTERNAL_SVC_LATENCY);
+    double internal_duration =
+        getMetricValue(event, EnrichedSpanConstants.INTERNAL_SVC_LATENCY, -1);
 
-    if (metricValue != null) {
-      builder.setInternalDurationMillis(metricValue.getValue().longValue());
+    if (internal_duration != -1) {
+      builder.setInternalDurationMillis((long) internal_duration);
     }
 
     // error count

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -220,11 +220,11 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
     builder.setEndTimeMillis(event.getEndTimeMillis());
     builder.setDurationMillis(event.getEndTimeMillis() - event.getStartTimeMillis());
 
-    //internal duration
-    MetricValue metricValue = event.getMetrics().getMetricMap()
-        .get(EnrichedSpanConstants.INTERNAL_SVC_LATENCY);
+    // internal duration
+    MetricValue metricValue =
+        event.getMetrics().getMetricMap().get(EnrichedSpanConstants.INTERNAL_SVC_LATENCY);
 
-    if(metricValue != null) {
+    if (metricValue != null) {
       builder.setInternalDurationMillis(metricValue.getValue().longValue());
     }
 

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/SpanEventViewGenerator.java
@@ -220,6 +220,14 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
     builder.setEndTimeMillis(event.getEndTimeMillis());
     builder.setDurationMillis(event.getEndTimeMillis() - event.getStartTimeMillis());
 
+    //internal duration
+    MetricValue metricValue = event.getMetrics().getMetricMap()
+        .get(EnrichedSpanConstants.INTERNAL_SVC_LATENCY);
+
+    if(metricValue != null) {
+      builder.setInternalDurationMillis(metricValue.getValue().longValue());
+    }
+
     // error count
     MetricValue errorMetric = event.getMetrics().getMetricMap().get(ERROR_COUNT_CONSTANT);
     if (errorMetric != null && errorMetric.getValue() > 0.0d) {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -22,6 +22,7 @@ import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Entity;
 import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.Metrics;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
@@ -319,6 +320,48 @@ public class SpanEventViewGeneratorTest {
     spanEventViewGenerator = new SpanEventViewGenerator();
     list = spanEventViewGenerator.process(trace);
     assertEquals(5, list.get(0).getApiTraceErrorSpanCount());
+  }
+
+  @Test
+  public void testEntrySpanInternalDuration() {
+    StructuredTrace.Builder traceBuilder = StructuredTrace.newBuilder();
+    traceBuilder
+        .setCustomerId("customer1")
+        .setTraceId(ByteBuffer.wrap("sample-trace-id".getBytes()))
+        .setEntityList(
+            Collections.singletonList(
+                Entity.newBuilder()
+                    .setCustomerId("customer1")
+                    .setEntityId("sample-entity-id")
+                    .setEntityName("sample-entity-name")
+                    .setEntityType("SERVICE")
+                    .build()))
+        .setEventList(
+            Collections.singletonList(
+                Event.newBuilder()
+                    .setCustomerId("customer1")
+                    .setEventId(ByteBuffer.wrap("sample-span-id".getBytes()))
+                    .setEventName("sample-span-name")
+                    .setEntityIdList(Collections.singletonList("sample-entity-id"))
+                    .setStartTimeMillis(System.currentTimeMillis())
+                    .setEndTimeMillis(System.currentTimeMillis())
+                    .setMetrics(Metrics.newBuilder().setMetricMap(Map.of(EnrichedSpanConstants.INTERNAL_SVC_LATENCY, MetricValue.newBuilder().setValue(50d).build())).build())
+                    .setAttributesBuilder(Attributes.newBuilder().setAttributeMap(Map.of(EnrichedSpanConstants.INTERNAL_SVC_LATENCY, AttributeValue.newBuilder().setValue("50").build())))
+                    .setEnrichedAttributesBuilder(
+                        Attributes.newBuilder().setAttributeMap(Maps.newHashMap()))
+                    .build()))
+        .setMetrics(Metrics.newBuilder().setMetricMap(new HashMap<>()).build())
+        .setEntityEdgeList(new ArrayList<>())
+        .setEventEdgeList(new ArrayList<>())
+        .setEntityEventEdgeList(new ArrayList<>())
+        .setStartTimeMillis(System.currentTimeMillis())
+        .setEndTimeMillis(System.currentTimeMillis());
+
+    StructuredTrace trace = traceBuilder.build();
+    SpanEventViewGenerator spanEventViewGenerator = new SpanEventViewGenerator();
+    List<SpanEventView> list = spanEventViewGenerator.process(trace);
+    long internalDurationMillis = list.get(0).getInternalDurationMillis();
+    Assertions.assertEquals(50, internalDurationMillis);
   }
 
   private Event createMockEventWithAttribute(String key, String value) {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -345,8 +345,19 @@ public class SpanEventViewGeneratorTest {
                     .setEntityIdList(Collections.singletonList("sample-entity-id"))
                     .setStartTimeMillis(System.currentTimeMillis())
                     .setEndTimeMillis(System.currentTimeMillis())
-                    .setMetrics(Metrics.newBuilder().setMetricMap(Map.of(EnrichedSpanConstants.INTERNAL_SVC_LATENCY, MetricValue.newBuilder().setValue(50d).build())).build())
-                    .setAttributesBuilder(Attributes.newBuilder().setAttributeMap(Map.of(EnrichedSpanConstants.INTERNAL_SVC_LATENCY, AttributeValue.newBuilder().setValue("50").build())))
+                    .setMetrics(
+                        Metrics.newBuilder()
+                            .setMetricMap(
+                                Map.of(
+                                    EnrichedSpanConstants.INTERNAL_SVC_LATENCY,
+                                    MetricValue.newBuilder().setValue(50d).build()))
+                            .build())
+                    .setAttributesBuilder(
+                        Attributes.newBuilder()
+                            .setAttributeMap(
+                                Map.of(
+                                    EnrichedSpanConstants.INTERNAL_SVC_LATENCY,
+                                    AttributeValue.newBuilder().setValue("50").build())))
                     .setEnrichedAttributesBuilder(
                         Attributes.newBuilder().setAttributeMap(Maps.newHashMap()))
                     .build()))


### PR DESCRIPTION
https://razorpay.atlassian.net/browse/OBSV-1118

- The metric is now natively stored in Pinot.
- Changes in query layer not a part of this PR.