### PR TITLE
Add `interna_duration_millis`to Raw Service View

### DIFF
--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/RawServiceView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/RawServiceView.avdl
@@ -18,6 +18,8 @@ protocol RawServiceViewProtocol {
 
     long duration_millis;
 
+    union { null, long } internal_duration_millis = null;
+
     union { null, string } span_kind = null;
 
     int error_count = 0;

--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
@@ -48,7 +48,7 @@ protocol SpanEventViewProtocol {
     long duration_millis = 0;
 
     //this will be >=0 only for spans with API_BOUNDARY_TYPE = ENTRY
-    long internal_duration_millis = -1;
+    union { null, long } internal_duration_millis = null;
 
     // span id of an entry api span.
     union { null, bytes } api_trace_id = null;

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
@@ -68,6 +68,14 @@ public class RawServiceViewGenerator extends BaseViewGenerator<RawServiceView> {
 
         builder.setStatusCode(EnrichedSpanUtils.getStatusCode(event));
 
+        // internal duration
+        double internal_duration =
+            getMetricValue(event, EnrichedSpanConstants.INTERNAL_SVC_LATENCY, -1);
+
+        if (internal_duration != -1) {
+          builder.setInternalDurationMillis((long) internal_duration);
+        }
+
         // If this is an API entry boundary span, copy the error count from the event to the view
         // because we want only API or service errors to be present in the view.
         MetricValue errorMetric =

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
@@ -72,6 +72,7 @@ public class RawServiceViewGenerator extends BaseViewGenerator<RawServiceView> {
         double internal_duration =
             getMetricValue(event, EnrichedSpanConstants.INTERNAL_SVC_LATENCY, -1);
 
+
         if (internal_duration != -1) {
           builder.setInternalDurationMillis((long) internal_duration);
         }

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/RawServiceViewGenerator.java
@@ -72,7 +72,6 @@ public class RawServiceViewGenerator extends BaseViewGenerator<RawServiceView> {
         double internal_duration =
             getMetricValue(event, EnrichedSpanConstants.INTERNAL_SVC_LATENCY, -1);
 
-
         if (internal_duration != -1) {
           builder.setInternalDurationMillis((long) internal_duration);
         }

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/RawServiceViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/RawServiceViewGeneratorTest.java
@@ -23,7 +23,8 @@ public class RawServiceViewGeneratorTest {
 
     List<RawServiceView> rawServiceViews = rawServiceViewGenerator.process(sampleTrace);
 
-    Long actualInternalDurationMillis = rawServiceViews.get(0).getInternalDurationMillis();
-    Assertions.assertNull(actualInternalDurationMillis);
+    Assertions.assertEquals(678, rawServiceViews.get(0).getInternalDurationMillis());
+
+    Assertions.assertNull(rawServiceViews.get(1).getInternalDurationMillis());
   }
 }

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/RawServiceViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/RawServiceViewGeneratorTest.java
@@ -1,0 +1,29 @@
+package org.hypertrace.viewgenerator.generators;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.viewgenerator.api.RawServiceView;
+import org.hypertrace.viewgenerator.generators.utils.TestUtilities;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RawServiceViewGeneratorTest {
+  private RawServiceViewGenerator rawServiceViewGenerator;
+
+  @BeforeEach
+  public void setup() {
+    rawServiceViewGenerator = new RawServiceViewGenerator();
+  }
+
+  @Test
+  public void testEntrySpanInternalDuration() throws FileNotFoundException {
+    StructuredTrace sampleTrace = TestUtilities.getSampleHotRodTrace();
+
+    List<RawServiceView> rawServiceViews = rawServiceViewGenerator.process(sampleTrace);
+
+    Long actualInternalDurationMillis = rawServiceViews.get(0).getInternalDurationMillis();
+    Assertions.assertNull(actualInternalDurationMillis);
+  }
+}

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/StructuredTrace-Hotrod.json
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/resources/StructuredTrace-Hotrod.json
@@ -97,6 +97,9 @@
         "metric_map": {
           "Duration": {
             "value": 678.0
+          },
+          "enriched.internal.duration.millis": {
+            "value": 678.0
           }
         }
       },
@@ -156,6 +159,9 @@
           },
           "API_NAME": {
             "value": "http get /dispatch"
+          },
+          "enriched.internal.duration.millis": {
+            "value": 678.0
           }
         }
       },


### PR DESCRIPTION
- Adding null so that the default value while reading is `null` (as 0 is a valid value of this metric, we ideally do not want records missing this field to be deserialised with this value as 0).