### PR TITLE
Change datatype of internal_duration_millis from union to long

### DIFF
--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiNodeInternalDurationEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiNodeInternalDurationEnricher.java
@@ -11,7 +11,6 @@ import org.hypertrace.core.datamodel.EventRefType;
 import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.ApiNode;
-import org.hypertrace.core.datamodel.shared.HexUtils;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
 import org.hypertrace.entity.constants.v1.BackendAttribute;
 import org.hypertrace.entity.service.constants.EntityConstants;
@@ -52,11 +51,6 @@ public class ApiNodeInternalDurationEnricher extends AbstractTraceEnricher {
             if (normalizedOutboundEdges.size() > 0) {
               totalWaitTime = calculateTotalWaitTime(normalizedOutboundEdges);
             }
-            LOG.info(
-                "Enriching event {} with {} val: {}",
-                HexUtils.getHex(entryEvent.getEventId()),
-                EnrichedSpanConstants.API_INTERNAL_DURATION,
-                entryApiBoundaryEventDuration - totalWaitTime);
             enrichEvent(entryEvent, entryApiBoundaryEventDuration, totalWaitTime);
           });
     }

--- a/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiNodeInternalDurationEnricher.java
+++ b/hypertrace-trace-enricher/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiNodeInternalDurationEnricher.java
@@ -11,6 +11,7 @@ import org.hypertrace.core.datamodel.EventRefType;
 import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.core.datamodel.shared.ApiNode;
+import org.hypertrace.core.datamodel.shared.HexUtils;
 import org.hypertrace.core.datamodel.shared.trace.AttributeValueCreator;
 import org.hypertrace.entity.constants.v1.BackendAttribute;
 import org.hypertrace.entity.service.constants.EntityConstants;
@@ -51,6 +52,11 @@ public class ApiNodeInternalDurationEnricher extends AbstractTraceEnricher {
             if (normalizedOutboundEdges.size() > 0) {
               totalWaitTime = calculateTotalWaitTime(normalizedOutboundEdges);
             }
+            LOG.info(
+                "Enriching event {} with {} val: {}",
+                HexUtils.getHex(entryEvent.getEventId()),
+                EnrichedSpanConstants.API_INTERNAL_DURATION,
+                entryApiBoundaryEventDuration - totalWaitTime);
             enrichEvent(entryEvent, entryApiBoundaryEventDuration, totalWaitTime);
           });
     }

--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
@@ -47,8 +47,8 @@ protocol SpanEventViewProtocol {
     // duration
     long duration_millis = 0;
 
-    //this will be >=0 only for spans with API_BOUNDARY_TYPE = ENTRY
-    union { null, long } internal_duration_millis = null;
+    //todo: this should be null by default. This schema change is incompatible
+    long internal_duration_millis = 0;
 
     // span id of an entry api span.
     union { null, bytes } api_trace_id = null;

--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
@@ -48,7 +48,7 @@ protocol SpanEventViewProtocol {
     long duration_millis = 0;
 
     //todo: this should be null by default. This schema change is incompatible
-    long internal_duration_millis = 0;
+    long internal_duration_millis = -1;
 
     // span id of an entry api span.
     union { null, bytes } api_trace_id = null;

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -329,7 +329,7 @@ public class SpanEventViewGeneratorTest {
     List<SpanEventView> list = spanEventViewGenerator.process(TestUtilities.getSampleHotRodTrace());
     long internalDurationMillis = list.get(0).getInternalDurationMillis();
     Assertions.assertEquals(678, internalDurationMillis);
-    Assertions.assertNull(list.get(1).getInternalDurationMillis());
+    Assertions.assertEquals(-1, list.get(1).getInternalDurationMillis());
   }
 
   private Event createMockEventWithAttribute(String key, String value) {


### PR DESCRIPTION
This will fix [this](https://razorpay.slack.com/archives/CU5GKS8MQ/p1672132191662159?thread_ts=1672123559.591109&cid=CU5GKS8MQ). Note: Have kept the default READ value to be `-1` as we can then filter on valid values on Explorer (`Internal Duration >= 0`). Ideally, this should be `null` in the table but that schema change is now incompatible.