### PR TITLE
Add tags_JSON to BackendEntityView and SpanEventView

### DIFF
--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/BackendEntityView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/BackendEntityView.avdl
@@ -52,6 +52,8 @@ protocol BackendEntityViewProtocol {
     // key:value pairs of all the associated tags to this span
     map<string> tags = {};
 
+    union {null, string} tags_json = null;
+
     // this span is associated to service if any
     union { null, string } caller_service_id = null;
 

--- a/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
+++ b/hypertrace-view-generator/hypertrace-view-generator-api/src/main/avro/SpanEventView.avdl
@@ -34,6 +34,8 @@ protocol SpanEventViewProtocol {
     // key:value pairs of all the associated tags to this span
     map<string> tags = {};
 
+    union {null, string} tags_json = null;
+
     // if this was an api span, result of the request 200, 500, etc
     // Api Trace attribute
     union { null, string } status_code = null;

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BackendEntityViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BackendEntityViewGenerator.java
@@ -118,6 +118,8 @@ public class BackendEntityViewGenerator extends BaseViewGenerator<BackendEntityV
 
       builder.setTags(getAttributeMap(event.getAttributes()));
 
+      builder.setTagsJson(OBJECT_MAPPER.writeValueAsString(getAttributeMap(event.getAttributes())));
+
       // this is the same for now
       builder.setDisplayName(event.getEventName());
       // status_code

--- a/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/main/java/org/hypertrace/viewgenerator/generators/BaseViewGenerator.java
@@ -1,5 +1,6 @@
 package org.hypertrace.viewgenerator.generators;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Timer;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -32,6 +33,7 @@ public abstract class BaseViewGenerator<OUT extends GenericRecord>
       PlatformMetricsRegistry.registerTimer(DataflowMetricUtils.ARRIVAL_LAG, new HashMap<>());
 
   static final String EMPTY_STRING = "";
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static double getMetricValue(Event event, String metricName, double defaultValue) {
     if (event.getMetrics() == null || event.getMetrics().getMetricMap().isEmpty()) {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/BackendEntityViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/BackendEntityViewGeneratorTest.java
@@ -22,8 +22,7 @@ public class BackendEntityViewGeneratorTest {
     List<BackendEntityView> backendEntityViews = backendEntityViewGenerator.process(trace);
     List<Event> computedBackendEvents = getEventsWithBackendEntity(trace);
     assertEntity(backendEntityViews, computedBackendEvents);
-    backendEntityViews
-        .forEach(event -> Assertions.assertNotNull(event.getTagsJson()));
+    backendEntityViews.forEach(event -> Assertions.assertNotNull(event.getTagsJson()));
   }
 
   private List<Event> getEventsWithBackendEntity(StructuredTrace trace) {

--- a/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/BackendEntityViewGeneratorTest.java
+++ b/hypertrace-view-generator/hypertrace-view-generator/src/test/java/org/hypertrace/viewgenerator/generators/BackendEntityViewGeneratorTest.java
@@ -10,6 +10,7 @@ import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 import org.hypertrace.viewgenerator.api.BackendEntityView;
 import org.hypertrace.viewgenerator.generators.utils.TestUtilities;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class BackendEntityViewGeneratorTest {
@@ -21,6 +22,8 @@ public class BackendEntityViewGeneratorTest {
     List<BackendEntityView> backendEntityViews = backendEntityViewGenerator.process(trace);
     List<Event> computedBackendEvents = getEventsWithBackendEntity(trace);
     assertEntity(backendEntityViews, computedBackendEvents);
+    backendEntityViews
+        .forEach(event -> Assertions.assertNotNull(event.getTagsJson()));
   }
 
   private List<Event> getEventsWithBackendEntity(StructuredTrace trace) {


### PR DESCRIPTION
- Leaves `tags` as is because `tags__KEYS` and `tags__VALUES` are derived from this column.
- Both of these columns are still needed for running `LIKE` and `IN` queries on Explorer.
- `tags_json` is a string serialised as a JSON string. The corresponding datatype in Pinot is `JSON`.
- We'll run only `CONTAINS_KEY` and `EQUALS` queries on this column, as there's no way to run these queries using the json index natively.